### PR TITLE
Update dependencies and plugin versions

### DIFF
--- a/swan-javadoc-coverage/pom.xml
+++ b/swan-javadoc-coverage/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <!--dependency>
@@ -117,13 +117,14 @@
         <dependency>
             <groupId>jdk.tools</groupId>
             <artifactId>jdk.tools</artifactId>
+            <version>1.8</version>
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -133,7 +134,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.10.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -155,7 +156,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.2</version>
                 <executions>
                     <!-- Exports JavaDocs of the JavaDoc Coverage Plugin to regular HTML files -->
                     <execution>

--- a/swan-pipeline/pom.xml
+++ b/swan-pipeline/pom.xml
@@ -9,11 +9,16 @@
     <packaging>jar</packaging>
 
 
-    <name>SWAN Core</name>
-    <description>SWAN uses fully automated machine-learning approaches to classify Java methods into security-relevant methods (SRM) and software vulnerabilities categories.
-        The methods are classified into the following security-relevant method categories sources, sinks, sanitizers and authentication. For the software vulnerability classes,
-        the following Common Weakness Enumeration (CWE) vulnerabilities are supported: OS Command Injection, Cross-site Scripting, SQL Injection, Missing Authentication, Open Redirect, Missing Authorisation, and Incorrect Authorisation.
-        SWAN detects methods from the provided source code and outputs a list of methods that can be used to configure static analysis tools.
+    <name>SWAN</name>
+    <description>SWAN uses fully automated machine-learning approaches to classify Java methods into security-relevant
+        methods (SRM) and software vulnerabilities categories.
+        The methods are classified into the following security-relevant method categories sources, sinks, sanitizers and
+        authentication. For the software vulnerability classes,
+        the following Common Weakness Enumeration (CWE) vulnerabilities are supported: OS Command Injection, Cross-site
+        Scripting, SQL Injection, Missing Authentication, Open Redirect, Missing Authorisation, and Incorrect
+        Authorisation.
+        SWAN detects methods from the provided source code and outputs a list of methods that can be used to configure
+        static analysis tools.
     </description>
     <url>https://github.com/secure-software-engineering/swan</url>
 
@@ -80,7 +85,7 @@
         <dependency>
             <groupId>nz.ac.waikato.cms.weka</groupId>
             <artifactId>weka-stable</artifactId>
-            <version>3.8.5</version>
+            <version>3.8.6</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
@@ -100,12 +105,12 @@
         <dependency>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
-            <version>4.3.0</version>
+            <version>4.4.0</version>
         </dependency>
         <dependency>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
-            <version>4.3.0</version>
+            <version>4.4.0</version>
             <classifier>models-english</classifier>
         </dependency>
         <dependency>
@@ -121,9 +126,8 @@
         <dependency>
             <groupId>dev.jeka</groupId>
             <artifactId>jeka-core</artifactId>
-            <version>0.9.0.M10</version>
+            <version>0.9.15.RELEASE</version>
         </dependency>
-        <!-- deeplearning4j-core: contains swanPipeline functionality and neural networks -->
         <dependency>
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-core</artifactId>
@@ -152,7 +156,7 @@
         <dependency>
             <groupId>ai.libs</groupId>
             <artifactId>mlplan-weka</artifactId>
-            <version>0.2.3</version>
+            <version>0.2.7</version>
         </dependency>
         <dependency>
             <groupId>org.graphstream</groupId>
@@ -162,24 +166,22 @@
         <dependency>
             <groupId>ai.libs</groupId>
             <artifactId>hasco-core</artifactId>
-            <version>0.2.5</version>
+            <version>0.2.7</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>1.7.36</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.32</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>4.6.2</version>
+            <version>4.6.3</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -192,7 +194,6 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.13.1</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/net.sf.meka/meka --><!-- https://mvnrepository.com/artifact/net.sf.meka/meka -->
         <dependency>
             <groupId>net.sf.meka</groupId>
             <artifactId>meka</artifactId>
@@ -242,17 +243,6 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${basedir}/target</directory>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
                 </configuration>
             </plugin>
             <plugin>
@@ -306,7 +296,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <version>3.3.2</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -332,7 +322,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Bump versions for junit (4.13.1 to 4.13.2), commons-io (2.7 to 2.11.0), weka (3.8.5 to 3.8.6), stanford-corenlp (4.3.0 to 4.4.0), jeka (0.9.0.M10 to 0.9.15.RELEASE), ml-plan (0.2.3 and 0.2.5 to 0.2.7), slf4j (1.7.32 to 1.7.36), picoli (4.6.2 to 4.6.3) and Maven plugins