### PR TITLE
Fix/Change dev-assist dialog box options

### DIFF
--- a/dev-assist/src/main/java/de/fraunhofer/iem/devassist/ui/dialog/MethodDialog.java
+++ b/dev-assist/src/main/java/de/fraunhofer/iem/devassist/ui/dialog/MethodDialog.java
@@ -291,8 +291,8 @@ public class MethodDialog extends DialogWrapper {
 
                 MethodNotifier publisher = messageBus.syncPublisher(MethodNotifier.ADD_UPDATE_DELETE_METHOD);
                 publisher.addNewExistingMethod(method);
-                super.doOKAction();
             }
+            super.doOKAction();
         }
     }
 

--- a/dev-assist/src/main/java/de/fraunhofer/iem/devassist/ui/dialog/SettingsDialog.java
+++ b/dev-assist/src/main/java/de/fraunhofer/iem/devassist/ui/dialog/SettingsDialog.java
@@ -65,6 +65,8 @@ public class SettingsDialog extends DialogWrapper {
     public SettingsDialog(Project project, boolean modal) {
 
         super(project, modal);
+        trainingPathCheckbox.setVisible(false);
+        trainingPanel.setVisible(false);
         this.project = project;
         resourceBundle = ResourceBundle.getBundle("dialog_messages");
         setTitle(resourceBundle.getString("SettingsDialog.Title"));
@@ -193,7 +195,6 @@ public class SettingsDialog extends DialogWrapper {
 
     @Override
     protected void doOKAction() {
-
         if (isOKActionEnabled()) {
 
             //ensure that required fields are populated


### PR DESCRIPTION
The option to allow users to add their training jar files is now disabled.
The bug in the method dialog box ok button is now fixed.